### PR TITLE
Add Nim 1.6.6

### DIFF
--- a/nightlies.txt
+++ b/nightlies.txt
@@ -44,3 +44,4 @@
 1.6.0 https://github.com/nim-lang/nightlies/releases/tag/2021-10-19-version-1-6-727c6378d2464090564dbcd9bc8b9ac648467e38
 1.6.2 https://github.com/nim-lang/nightlies/releases/tag/2021-12-17-version-1-6-9084d9bc02bcd983b81a4c76a05f27b9ce2707dd
 1.6.4 https://github.com/nim-lang/nightlies/releases/tag/2022-02-09-version-1-6-7994556f3804c217035c44b453a3feec64405758
+1.6.6 https://github.com/nim-lang/nightlies/releases/tag/2022-05-05-version-1-6-0565a70eab02122ce278b98181c7d1170870865c


### PR DESCRIPTION
Links:
- https://nim-lang.org/blog/2022/05/05/version-166-released.html
- https://forum.nim-lang.org/t/9144
- https://github.com/nim-lang/Nim/compare/v1.6.4...v1.6.6

---

Released 15 minutes ago.

Please double check that the nightlies link is correct. I think that it is:

```console
$ cd /tmp
$ curl -sSfL -o 1.tar.xz https://github.com/nim-lang/nightlies/releases/download/2022-05-05-version-1-6-0565a70eab02122ce278b98181c7d1170870865c/nim-1.6.6-linux_x64.tar.xz
$ curl -sSfL -o 2.tar.xz https://nim-lang.org/download/nim-1.6.6-linux_x64.tar.xz
$ diff -s 1.tar.xz 2.tar.xz
Files 1.tar.xz and 2.tar.xz are identical
$ curl -sSfL -o 3.tar.xz https://github.com/nim-lang/nightlies/releases/download/2022-05-05-version-1-6-0565a70eab02122ce278b98181c7d1170870865c/nim-1.6.6-windows_x64.zip
$ curl -sSfL -o 4.tar.xz https://nim-lang.org/download/nim-1.6.6_x64.zip
$ diff -s 3.tar.xz 4.tar.xz
Files 3.tar.xz and 4.tar.xz are identical
```

Thanks for your work in this repo.