### PR TITLE
Add Nim 1.6.8

### DIFF
--- a/nightlies.txt
+++ b/nightlies.txt
@@ -45,3 +45,4 @@
 1.6.2 https://github.com/nim-lang/nightlies/releases/tag/2021-12-17-version-1-6-9084d9bc02bcd983b81a4c76a05f27b9ce2707dd
 1.6.4 https://github.com/nim-lang/nightlies/releases/tag/2022-02-09-version-1-6-7994556f3804c217035c44b453a3feec64405758
 1.6.6 https://github.com/nim-lang/nightlies/releases/tag/2022-05-05-version-1-6-0565a70eab02122ce278b98181c7d1170870865c
+1.6.8 https://github.com/nim-lang/nightlies/releases/tag/2022-09-27-version-1-6-c9f46ca8c9eeca8b5f68591b1abe14b962f80a4c


### PR DESCRIPTION
Links:
- https://nim-lang.org/blog/2022/09/27/version-168-released.html
- https://github.com/nim-lang/Nim/compare/v1.6.6...v1.6.8
- https://forum.nim-lang.org/t/9494

Previous bump: #21

---

Double-checking that it's the correct nightly release:

```console
$ cd /tmp
$ curl -sSfL -o 1.tar.xz https://nim-lang.org/download/nim-1.6.8-linux_x64.tar.xz
$ curl -sSfL -o 2.tar.xz https://github.com/nim-lang/nightlies/releases/download/2022-09-27-version-1-6-c9f46ca8c9eeca8b5f68591b1abe14b962f80a4c/nim-1.6.8-linux_x64.tar.xz
$ diff -s 1.tar.xz 2.tar.xz
Files 1.tar.xz and 2.tar.xz are identical
```